### PR TITLE
Fixed Unicode Bug for Form Parameter Values

### DIFF
--- a/ninja-undertow/src/main/java/ninja/undertow/NinjaUndertow.java
+++ b/ninja-undertow/src/main/java/ninja/undertow/NinjaUndertow.java
@@ -27,9 +27,10 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.BlockingHandler;
 import io.undertow.server.handlers.PathHandler;
 import io.undertow.server.handlers.RequestDumpingHandler;
-import io.undertow.server.handlers.form.EagerFormParsingHandler;
 import javax.net.ssl.SSLContext;
 import ninja.standalone.AbstractStandalone;
+import ninja.undertow.util.EagerFormParsingHandlerWithCharset;
+import ninja.utils.NinjaConstant;
 import ninja.Bootstrap;
 import org.apache.commons.lang3.StringUtils;
 
@@ -144,7 +145,7 @@ public class NinjaUndertow extends AbstractStandalone<NinjaUndertow> {
         }
         
         // then eagerly parse form data (which is then included as an attachment)
-        h = new EagerFormParsingHandler().setNext(h);
+        h = new EagerFormParsingHandlerWithCharset(null, NinjaConstant.UTF_8).setNext(h);
         
         // then requests MUST be blocking for IO to function
         h = new BlockingHandler(h);

--- a/ninja-undertow/src/main/java/ninja/undertow/util/EagerFormParsingHandlerWithCharset.java
+++ b/ninja-undertow/src/main/java/ninja/undertow/util/EagerFormParsingHandlerWithCharset.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package ninja.undertow.util;
+
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.server.handlers.form.EagerFormParsingHandler;
+import io.undertow.server.handlers.form.FormDataParser;
+import io.undertow.server.handlers.form.FormParserFactory;
+
+/**
+ * This class is based on the original {@link EagerFormParsingHandler}, but uses a different {@link FormParserFactory} in order to set a custom charset for form parsing.
+ *
+ * @author Jens Fendler
+ */
+public class EagerFormParsingHandlerWithCharset implements HttpHandler {
+
+    private volatile HttpHandler next = ResponseCodeHandler.HANDLE_404;
+    private final FormParserFactory formParserFactory;
+	private String defaultCharset;
+
+    public EagerFormParsingHandlerWithCharset() {
+    	this(null);
+    }
+    
+    public EagerFormParsingHandlerWithCharset(final FormParserFactory formParserFactory) {
+    	this(formParserFactory, null);
+    }
+
+    public EagerFormParsingHandlerWithCharset(final FormParserFactory formParserFactory, String defaultCharset) {
+    	this.defaultCharset = defaultCharset;
+    	if ( formParserFactory == null ) {
+    		// build the factory if not provided
+        	FormParserFactory.Builder builder = FormParserFactory.builder();
+        	builder.setDefaultCharset(this.defaultCharset);
+        	this.formParserFactory = builder.build();
+    	} else {
+    		this.formParserFactory = formParserFactory;
+    	}
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        FormDataParser parser = formParserFactory.createParser(exchange);
+        if (parser == null) {
+            next.handleRequest(exchange);
+            return;
+        }
+        if(exchange.isBlocking()) {
+            exchange.putAttachment(FormDataParser.FORM_DATA, parser.parseBlocking());
+            next.handleRequest(exchange);
+        } else {
+            parser.parse(next);
+        }
+    }
+
+    public HttpHandler getNext() {
+        return next;
+    }
+
+    public EagerFormParsingHandlerWithCharset setNext(final HttpHandler next) {
+        Handlers.handlerNotNull(next);
+        this.next = next;
+        return this;
+    }
+}

--- a/ninja-undertow/src/test/java/ninja/undertow/UndertowIntegrationTest.java
+++ b/ninja-undertow/src/test/java/ninja/undertow/UndertowIntegrationTest.java
@@ -36,7 +36,6 @@ import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.is;
 
 public class UndertowIntegrationTest {
     static private final Logger log = LoggerFactory.getLogger(UndertowIntegrationTest.class);
@@ -103,7 +102,7 @@ public class UndertowIntegrationTest {
     
     @Test
     public void withFormParameters() throws Exception {
-        Request request
+    	Request request
             = requestBuilder(standalone, "/parameters")
                 .post(new FormBody.Builder()
                     .add("a", "joe")
@@ -116,6 +115,24 @@ public class UndertowIntegrationTest {
         assertThat(response.code(), is(200));
         assertThat(response.header("Content-Type"), equalToIgnoringCase("text/html; charset=utf-8"));
         assertThat(response.body().string(), is("a=joe, b=2"));
+    }
+    
+    @Test
+    public void withFormParametersUnicode() throws Exception {
+        String unicodeString = "Joe has $ — Jens has €. ÄÖÜßäöü";
+    	Request request
+            = requestBuilder(standalone, "/parameters")
+                .post(new FormBody.Builder()
+                    .add("a", unicodeString)
+                    .add("b", "2")
+                    .build())
+                .build();
+        
+        Response response = executeRequest(client, request);
+        
+        assertThat(response.code(), is(200));
+        assertThat(response.header("Content-Type"), equalToIgnoringCase("text/html; charset=utf-8"));
+        assertThat(response.body().string(), is("a=" + unicodeString + ", b=2"));
     }
     
     @Test


### PR DESCRIPTION
Parameter values from multipart forms were not treated as UTF-8. Thus non-ASCII-range characters were garbled when received on the server side.
- Added custom EagerFormParsingHandlerWithCharset to apply a UTF-8
  conversion by default when parsing form data.
- Added test case to send unicode characters as multipart-form data.
